### PR TITLE
Fix: Resolve errors in RegisterActivity and related files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,8 +60,9 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation "androidx.core:core-ktx:1.12.0" // Specify a recent version explicitly
+    implementation "androidx.activity:activity-ktx:1.8.2" // Specify a recent version explicitly
+    implementation "androidx.appcompat:appcompat:1.6.1" // Specify a recent version explicitly
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'

--- a/app/src/main/kotlin/com/upidea/astrolumina/data/local/entity/UserEntity.kt
+++ b/app/src/main/kotlin/com/upidea/astrolumina/data/local/entity/UserEntity.kt
@@ -10,6 +10,7 @@ data class UserEntity(
     val email: String,
     val password: String,
     val birthDate: String,
-    val birthTime: String,
-    val birthPlace: String
+    val birthTime: String? = null, // Made nullable with default
+    val birthPlace: String? = null, // Made nullable with default
+    val gender: String // Added gender
 )

--- a/app/src/main/kotlin/com/upidea/astrolumina/data/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/upidea/astrolumina/data/repository/UserRepository.kt
@@ -1,6 +1,6 @@
 package com.upidea.astrolumina.data.repository
 
-import com.upidea.astrolumina.data.entity.UserEntity
+import com.upidea.astrolumina.data.local.entity.UserEntity
 import com.upidea.astrolumina.data.local.dao.UserDao
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/app/src/main/kotlin/com/upidea/astrolumina/ui/RegisterActivity.kt
+++ b/app/src/main/kotlin/com/upidea/astrolumina/ui/RegisterActivity.kt
@@ -6,6 +6,7 @@ import android.widget.*
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.upidea.astrolumina.R
+import com.upidea.astrolumina.data.local.entity.UserEntity // Added import
 import com.upidea.astrolumina.ui.auth.viewmodel.RegisterViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -38,13 +39,16 @@ class RegisterActivity : AppCompatActivity() {
             }
 
             if (email.isNotEmpty() && password.length >= 6 && name.isNotEmpty() && gender.isNotEmpty()) {
-                registerViewModel.registerUser(
+                val userToRegister = UserEntity(
+                    name = name,
                     email = email,
                     password = password,
-                    name = name,
                     birthDate = birthDate,
+                    birthTime = null,
+                    birthPlace = null,
                     gender = gender
                 )
+                registerViewModel.registerUser(userToRegister)
 
                 Toast.makeText(this, "Kayıt başarılı!", Toast.LENGTH_SHORT).show()
                 startActivity(Intent(this, LoginActivity::class.java))

--- a/app/src/main/kotlin/viewmodel/RegisterViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/RegisterViewModel.kt
@@ -2,8 +2,8 @@ package com.upidea.astrolumina.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.upidea.astrolumina.data.entity.UserEntity
-import com.upidea.astrolumina.repository.UserRepository
+import com.upidea.astrolumina.data.local.entity.UserEntity
+import com.upidea.astrolumina.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject


### PR DESCRIPTION
- I added dependencies for `androidx.activity:activity-ktx` and ensured `androidx.appcompat:appcompat` and `androidx.core:core-ktx` are present to resolve issues with `AppCompatActivity` and `viewModels`.
- I updated `UserEntity.kt`:
    - Added `gender: String` field.
    - Made `birthTime` and `birthPlace` nullable with default null values to align with data collected in `RegisterActivity`.
- I updated `RegisterActivity.kt`:
    - Corrected the call to `registerViewModel.registerUser` to construct and pass a `UserEntity` object, resolving the "Too many arguments" error.
    - Added import for `UserEntity`.

These changes address various unresolved reference errors and the incorrect ViewModel method call in `RegisterActivity.kt`.